### PR TITLE
Add date range filter, checkbox store filter, and Revenue at Risk KPI

### DIFF
--- a/analytics_app/dashboards/xanalife/revenue_dashboard.py
+++ b/analytics_app/dashboards/xanalife/revenue_dashboard.py
@@ -107,6 +107,19 @@ KE_SCHOOL_TERMS = [
     ("2026-05-04", "2026-08-14", "Term 2 2026"),
 ]
 
+_MONTHS = [
+    ("Sep 2025", "2025-09-01", "2025-09-30"),
+    ("Oct 2025", "2025-10-01", "2025-10-31"),
+    ("Nov 2025", "2025-11-01", "2025-11-30"),
+    ("Dec 2025", "2025-12-01", "2025-12-31"),
+    ("Jan 2026", "2026-01-01", "2026-01-31"),
+    ("Feb 2026", "2026-02-01", "2026-02-28"),
+    ("Mar 2026", "2026-03-01", "2026-03-31"),
+]
+_MONTH_LABELS = [m[0] for m in _MONTHS]
+_MONTH_STARTS = {m[0]: m[1] for m in _MONTHS}
+_MONTH_ENDS   = {m[0]: m[2] for m in _MONTHS}
+
 # ── Session state ──────────────────────────────────────────────────────────────
 
 for key in ("ci_data", "scr_data", "sa_data", "ma_data", "ov_data", "stores_df"):
@@ -157,7 +170,13 @@ with st.sidebar:
         elif division == "Supermarket":
             _pool = _pool[~_pool["STORE_CODE"].isin(_PHARMACY_CODES)]
         _store_pool = _pool["STORE_NAME"].tolist()
-        selected_stores = st.multiselect("Stores", _store_pool, default=_store_pool)
+        all_stores_checked = st.checkbox("All Stores", value=True)
+        indiv = []
+        if not all_stores_checked:
+            for sn in _store_pool:
+                if st.checkbox(sn, value=True, key=f"chk_store_{sn}"):
+                    indiv.append(sn)
+        selected_stores = _store_pool[:] if all_stores_checked else indiv
         st.caption(
             "Applies to: Revenue · Basket · Margin · SCR · Stockout\n"
             "Not filterable: Cash Integrity · Invoices · Loyalty"
@@ -165,19 +184,30 @@ with st.sidebar:
     else:
         selected_stores = []
 
+    section_header("Date Range", margin_top=8)
+    from_label = st.selectbox("From", _MONTH_LABELS, index=0)
+    to_label   = st.selectbox("To",   _MONTH_LABELS, index=len(_MONTH_LABELS) - 1)
+    if _MONTH_LABELS.index(from_label) > _MONTH_LABELS.index(to_label):
+        st.warning("'From' is after 'To' — reset to full range.")
+        from_label = _MONTH_LABELS[0]
+        to_label   = _MONTH_LABELS[-1]
+    start_date = _MONTH_STARTS[from_label]
+    end_date   = _MONTH_ENDS[to_label]
+
 # ── Store filter — resolve defaults and compute cache key ─────────────────────
 
 if not selected_stores and st.session_state.stores_df is not None:
     selected_stores = st.session_state.stores_df["STORE_NAME"].tolist()
 
-filter_key = frozenset(selected_stores)
+store_key  = frozenset(selected_stores)
+filter_key = (store_key, (start_date, end_date))
 
 # When all stores are selected, pass [] to get_analyses — bypasses the IN subquery
-# and restores full revenue (51.11M). The IN subquery excludes ~231 transactions
+# and restores full revenue. The IN subquery excludes ~231 transactions
 # whose store_product_ids have no match in inventory_store_products (~1% of rows).
 _all_store_names = (frozenset(st.session_state.stores_df["STORE_NAME"].tolist())
                     if st.session_state.stores_df is not None else frozenset())
-effective_stores = [] if filter_key == _all_store_names else selected_stores
+effective_stores = [] if store_key == _all_store_names else selected_stores
 
 # ══════════════════════════════════════════════════════════════════════════════
 # OVERVIEW
@@ -185,13 +215,13 @@ effective_stores = [] if filter_key == _all_store_names else selected_stores
 
 if page == "Overview":
 
-    expected_ov = {label for label, _ in ov.get_analyses()}
+    expected_ov = {label for label, _ in ov.get_analyses(effective_stores, start_date, end_date)}
     if (not st.session_state.ov_data
             or st.session_state.ov_data.get("_filter_key") != filter_key
             or not expected_ov.issubset(st.session_state.ov_data.keys())):
         with st.spinner("Loading overview…"):
             st.session_state.ov_data = {"_filter_key": filter_key}
-            for label, sql in ov.get_analyses(effective_stores):
+            for label, sql in ov.get_analyses(effective_stores, start_date, end_date):
                 st.session_state.ov_data[label] = ov.run_query_(sql)
 
     O = st.session_state.ov_data
@@ -228,14 +258,36 @@ if page == "Overview":
     st.caption("Sep 2025 – March 18 2026 · Data cutoff")
     st.markdown("<div style='margin-bottom:16px'></div>", unsafe_allow_html=True)
 
+    _scr_key = "SCR Summary — Stockouts + Top Substitute"
+    _scr_ready = (
+        isinstance(st.session_state.scr_data, dict)
+        and st.session_state.scr_data.get("_filter_key") == filter_key
+        and _scr_key in st.session_state.scr_data
+    )
+    if not _scr_ready:
+        _scr_sql = dict(scr.get_analyses(effective_stores, start_date, end_date))[_scr_key]
+        if not isinstance(st.session_state.scr_data, dict) or st.session_state.scr_data.get("_filter_key") != filter_key:
+            st.session_state.scr_data = {"_filter_key": filter_key}
+        with st.spinner("Loading revenue at risk…"):
+            st.session_state.scr_data[_scr_key] = scr.run_query_(_scr_sql)
+    _scr_ov = st.session_state.scr_data.get(_scr_key)
+    if _scr_ov is not None and not _scr_ov.empty:
+        _scr_ov = _scr_ov.copy()
+        _scr_ov["REVENUE_AT_RISK_KES"] = pd.to_numeric(_scr_ov["REVENUE_AT_RISK_KES"], errors="coerce").fillna(0)
+        rar_kes   = float(_scr_ov["REVENUE_AT_RISK_KES"].sum())
+        rar_count = len(_scr_ov)
+    else:
+        rar_kes   = 0.0
+        rar_count = 0
+
     c1, c2, c3, c4, c5 = st.columns(5)
     with c1:
         kpi_card("Total Revenue (YTD)", fmt_ksh(rev["TOTAL_REVENUE"]),
                  f"{int(rev['TOTAL_TRANSACTIONS']):,} transactions", COLORS["primary"])
     with c2:
-        kpi_card(month_label, fmt_ksh(rev["REVENUE_THIS_MONTH"]),
-                 f"{'+' if mom_pct >= 0 else ''}{mom_pct:.1f}% vs prior month",
-                 COLORS["success"] if mom_pct >= 0 else COLORS["danger"])
+        kpi_card("Revenue at Risk (SCR)", fmt_ksh(rar_kes),
+                 f"Across {rar_count} products currently out of stock",
+                 COLORS["danger"] if rar_kes > 0 else COLORS["muted"])
     with c3:
         kpi_card("Avg Sale Margin", f"{avg_sale_margin_ov:.1f}%",
                  f"Portfolio margin (total profit ÷ total revenue): {portfolio_margin_ov:.1f}%",
@@ -301,11 +353,13 @@ if page == "Overview":
 
 if page == "Cash Integrity":
 
-    expected_ci = {label for label, _ in ci.ANALYSES}
-    if not st.session_state.ci_data or not expected_ci.issubset(st.session_state.ci_data.keys()):
+    expected_ci = {label for label, _ in ci.get_analyses()}
+    if (not st.session_state.ci_data
+            or st.session_state.ci_data.get("_filter_key") != filter_key
+            or not expected_ci.issubset(st.session_state.ci_data.keys())):
         with st.spinner("Loading…"):
-            st.session_state.ci_data = {}
-            for label, sql in ci.ANALYSES:
+            st.session_state.ci_data = {"_filter_key": filter_key}
+            for label, sql in ci.get_analyses(start_date, end_date):
                 st.session_state.ci_data[label] = ci.run_query_(sql)
 
     D        = st.session_state.ci_data
@@ -547,13 +601,13 @@ if page == "Cash Integrity":
 
 if page == "Stock Intelligence":
 
-    expected_scr = {label for label, _ in scr.get_analyses()}
+    expected_scr = {label for label, _ in scr.get_analyses(effective_stores, start_date, end_date)}
     if (not st.session_state.scr_data
             or st.session_state.scr_data.get("_filter_key") != filter_key
             or not expected_scr.issubset(st.session_state.scr_data.keys())):
         with st.spinner("Loading…"):
             st.session_state.scr_data = {"_filter_key": filter_key}
-            for label, sql in scr.get_analyses(effective_stores):
+            for label, sql in scr.get_analyses(effective_stores, start_date, end_date):
                 st.session_state.scr_data[label] = scr.run_query_(sql)
 
     S         = st.session_state.scr_data
@@ -690,13 +744,13 @@ if page == "Stock Intelligence":
 
 if page == "Revenue Intelligence":
 
-    expected_sa = {label for label, _ in sa.get_analyses()}
+    expected_sa = {label for label, _ in sa.get_analyses(effective_stores, start_date, end_date)}
     if (not st.session_state.sa_data
             or st.session_state.sa_data.get("_filter_key") != filter_key
             or not expected_sa.issubset(st.session_state.sa_data.keys())):
         with st.spinner("Loading…"):
             st.session_state.sa_data = {"_filter_key": filter_key}
-            for label, sql in sa.get_analyses(effective_stores):
+            for label, sql in sa.get_analyses(effective_stores, start_date, end_date):
                 st.session_state.sa_data[label] = sa.run_query_(sql)
 
     A              = st.session_state.sa_data
@@ -997,7 +1051,7 @@ if page == "Revenue Intelligence":
             "Negative gap = Katani stronger → growth opportunity at Syokimau.")
 
         if not loc_opp.empty:
-            _months = max((pd.Timestamp.now() - pd.Timestamp("2025-09-01")).days / 30.44, 1)
+            _months = max((pd.Timestamp(end_date) - pd.Timestamp(start_date)).days / 30.44, 1)
 
             opp_display = loc_opp.copy()
             opp_display["monthly_upside"] = (opp_display["GAP"].abs() / _months).round(0)
@@ -1065,13 +1119,13 @@ if page == "Revenue Intelligence":
 
 if page == "Profit Margins":
 
-    expected_ma = {label for label, _ in ma.get_analyses()}
+    expected_ma = {label for label, _ in ma.get_analyses(effective_stores, start_date, end_date)}
     if (not st.session_state.ma_data
             or st.session_state.ma_data.get("_filter_key") != filter_key
             or not expected_ma.issubset(st.session_state.ma_data.keys())):
         with st.spinner("Loading…"):
             st.session_state.ma_data = {"_filter_key": filter_key}
-            for label, sql in ma.get_analyses(effective_stores):
+            for label, sql in ma.get_analyses(effective_stores, start_date, end_date):
                 st.session_state.ma_data[label] = ma.run_query_(sql)
 
     M          = st.session_state.ma_data

--- a/analytics_app/dashboards/xanalife/scripts/cash_integrity_analysis.py
+++ b/analytics_app/dashboards/xanalife/scripts/cash_integrity_analysis.py
@@ -6,10 +6,12 @@ import pandas as pd
 from connect_to_snowflake import run_query_
 
 
+
 # ── Config ─────────────────────────────────────────────────────────────────────
 
 SHIFTS   = "hospitals.xanalife_clean.reception_reception_shifts"
 GO_LIVE  = "'2025-09-01'"
+GO_END   = "'2026-03-31'"
 EXCL_SYS = "(5, 1719, 1741, 1744, 1746, 1739)"
 EXCL_SUP = "('sudo', 'Mrs. Xana  Admin', 'Mrs. Carole  Herzog')"
 
@@ -27,6 +29,7 @@ WITH user_variance AS (
               NULLIF(SUM(TRY_TO_NUMBER(system_closing_balance)), 0) * 100, 2)  AS variance_pct
     FROM {SHIFTS}
     WHERE TRY_TO_TIMESTAMP(created_at) >= {GO_LIVE}
+      AND TRY_TO_TIMESTAMP(created_at) <= {GO_END}
       AND closed_at IS NOT NULL AND closed_at != ''
       AND user_id NOT IN {EXCL_SYS}
       AND confirmed_by NOT IN {EXCL_SUP}
@@ -59,6 +62,7 @@ SELECT
           NULLIF(SUM(TRY_TO_NUMBER(system_closing_balance)),0)*100,2) AS variance_pct
 FROM {SHIFTS}
 WHERE TRY_TO_TIMESTAMP(created_at) >= {GO_LIVE}
+  AND TRY_TO_TIMESTAMP(created_at) <= {GO_END}
   AND closed_at IS NOT NULL AND closed_at != ''
   AND user_id NOT IN {EXCL_SYS}
   AND confirmed_by NOT IN {EXCL_SUP}
@@ -82,6 +86,7 @@ SELECT
     closed_at
 FROM {SHIFTS}
 WHERE TRY_TO_TIMESTAMP(created_at) >= {GO_LIVE}
+  AND TRY_TO_TIMESTAMP(created_at) <= {GO_END}
   AND closed_at IS NOT NULL AND closed_at != ''
   AND TRY_TO_NUMBER(cashier_closing_balance) > 0
   AND ABS(TRY_TO_NUMBER(closing_variance)) > ABS(TRY_TO_NUMBER(system_closing_balance))
@@ -98,6 +103,7 @@ SELECT
     SUM(TRY_TO_NUMBER(system_closing_balance))                       AS cash_at_risk_supervised
 FROM {SHIFTS}
 WHERE TRY_TO_TIMESTAMP(created_at) >= {GO_LIVE}
+  AND TRY_TO_TIMESTAMP(created_at) <= {GO_END}
   AND closed_at IS NOT NULL AND closed_at != ''
   AND user_id NOT IN {EXCL_SYS}
   AND confirmed_by NOT IN {EXCL_SUP}
@@ -114,6 +120,7 @@ SELECT
     COUNT(DISTINCT user_id)                               AS stations_with_unclosed
 FROM {SHIFTS}
 WHERE TRY_TO_TIMESTAMP(created_at) >= {GO_LIVE}
+  AND TRY_TO_TIMESTAMP(created_at) <= {GO_END}
   AND (closed_at IS NULL OR closed_at = '')
   AND user_id NOT IN {EXCL_SYS}
 """
@@ -134,6 +141,7 @@ SELECT
               THEN TRY_TO_NUMBER(total_sales) ELSE 0 END), 0)           AS revenue_unclosed_kes
 FROM {SHIFTS}
 WHERE TRY_TO_TIMESTAMP(created_at) >= {GO_LIVE}
+  AND TRY_TO_TIMESTAMP(created_at) <= {GO_END}
   AND user_id NOT IN {EXCL_SYS}
 GROUP BY user_id
 ORDER BY unclosed_rate_pct DESC
@@ -151,6 +159,7 @@ SELECT
               THEN TRY_TO_NUMBER(total_sales) ELSE 0 END), 0)           AS revenue_at_risk_kes
 FROM {SHIFTS}
 WHERE TRY_TO_TIMESTAMP(created_at) >= {GO_LIVE}
+  AND TRY_TO_TIMESTAMP(created_at) <= {GO_END}
   AND user_id NOT IN {EXCL_SYS}
 GROUP BY 1
 ORDER BY 1
@@ -170,6 +179,7 @@ SELECT
     confirmed_by                               AS supervisor
 FROM {SHIFTS}
 WHERE TRY_TO_TIMESTAMP(created_at) >= {GO_LIVE}
+  AND TRY_TO_TIMESTAMP(created_at) <= {GO_END}
   AND user_id NOT IN {EXCL_SYS}
   AND DATEDIFF('hour',
         TRY_TO_TIMESTAMP(opened_at),
@@ -207,6 +217,7 @@ WITH deduped AS (
     FROM hospitals.xanalife_clean.finance_invoices
     WHERE TRY_TO_NUMBER(balance) > 0
       AND TRY_TO_TIMESTAMP(created_at) >= '2025-09-01'
+      AND TRY_TO_TIMESTAMP(created_at) <= '2026-03-31'
       AND deleted_at IS NULL
     GROUP BY id
 )
@@ -231,6 +242,7 @@ WITH deduped AS (
     FROM hospitals.xanalife_clean.finance_invoices
     WHERE TRY_TO_NUMBER(balance) > 0
       AND TRY_TO_TIMESTAMP(created_at) >= '2025-09-01'
+      AND TRY_TO_TIMESTAMP(created_at) <= '2026-03-31'
       AND deleted_at IS NULL
     GROUP BY id
 )
@@ -262,6 +274,7 @@ WITH deduped AS (
     FROM hospitals.xanalife_clean.finance_invoices
     WHERE TRY_TO_NUMBER(balance) > 0
       AND TRY_TO_TIMESTAMP(created_at) >= '2025-09-01'
+      AND TRY_TO_TIMESTAMP(created_at) <= '2026-03-31'
       AND deleted_at IS NULL
     GROUP BY id
 )
@@ -281,20 +294,27 @@ ORDER BY outstanding_balance_kes DESC
 
 # ── Registry ────────────────────────────────────────────────────────────────────
 
-ANALYSES = [
-    ("Analysis 1 — Pareto by Station",         SQL_PARETO),
-    ("Analysis 2 — Monthly Variance Trend",    SQL_MONTHLY_TREND),
-    ("Analysis 3 — Anomalous Shifts",          SQL_ANOMALOUS),
-    ("Analysis 4 — Supervisor Correlation",    SQL_SUPERVISOR),
-    ("Analysis 5 — Unclosed Shift Exposure",   SQL_UNCLOSED_EXPOSURE),
-    ("Analysis 6 — Unclosed by Station",       SQL_UNCLOSED_BY_STATION),
-    ("Analysis 7 — Unclosed Shift Trend",      SQL_UNCLOSED_TREND),
-    ("Analysis 8 — Long-Duration Open Shifts", SQL_LONG_OPEN),
-    ("Analysis 9 — Daily Compliance Report",   SQL_DAILY_COMPLIANCE),
-    ("Invoice Summary",                        SQL_INVOICE_SUMMARY),
-    ("Invoice By Creditor",                    SQL_INVOICE_BY_CREDITOR),
-    ("Invoice List",                           SQL_INVOICE_LIST),
-]
+def get_analyses(start_date='2025-09-01', end_date='2026-03-31'):
+    sd = f"'{start_date}'"
+    ed = f"'{end_date}'"
+    def _sub(sql):
+        return sql.replace(GO_LIVE, sd).replace(GO_END, ed)
+    return [
+        ("Analysis 1 — Pareto by Station",         _sub(SQL_PARETO)),
+        ("Analysis 2 — Monthly Variance Trend",    _sub(SQL_MONTHLY_TREND)),
+        ("Analysis 3 — Anomalous Shifts",          _sub(SQL_ANOMALOUS)),
+        ("Analysis 4 — Supervisor Correlation",    _sub(SQL_SUPERVISOR)),
+        ("Analysis 5 — Unclosed Shift Exposure",   _sub(SQL_UNCLOSED_EXPOSURE)),
+        ("Analysis 6 — Unclosed by Station",       _sub(SQL_UNCLOSED_BY_STATION)),
+        ("Analysis 7 — Unclosed Shift Trend",      _sub(SQL_UNCLOSED_TREND)),
+        ("Analysis 8 — Long-Duration Open Shifts", _sub(SQL_LONG_OPEN)),
+        ("Analysis 9 — Daily Compliance Report",   _sub(SQL_DAILY_COMPLIANCE)),
+        ("Invoice Summary",                        _sub(SQL_INVOICE_SUMMARY)),
+        ("Invoice By Creditor",                    _sub(SQL_INVOICE_BY_CREDITOR)),
+        ("Invoice List",                           _sub(SQL_INVOICE_LIST)),
+    ]
+
+ANALYSES = get_analyses()
 
 
 def run_all() -> dict:
@@ -302,7 +322,6 @@ def run_all() -> dict:
     for label, sql in ANALYSES:
         print(f"\n{'='*60}\n  {label}\n{'='*60}")
         df = run_query_(sql)
-        df.columns = df.columns.str.upper()
         print(df.to_string(index=False))
         results[label] = df
     print("\n\nAll 9 analyses complete.")

--- a/analytics_app/dashboards/xanalife/scripts/margin_analysis.py
+++ b/analytics_app/dashboards/xanalife/scripts/margin_analysis.py
@@ -44,7 +44,8 @@ WITH line_margins AS (
     FROM hospitals.xanalife_clean.evaluation_pos_sale_details s
     JOIN hospitals.xanalife_clean.inventory_store_products p
         ON s.store_product_id = p.id
-    WHERE TRY_TO_TIMESTAMP(s.created_at) >= '2025-09-01'
+    WHERE TRY_TO_TIMESTAMP(s.created_at) >= {start_date}
+      AND TRY_TO_TIMESTAMP(s.created_at) <= {end_date}
       AND s.status != 'canceled'
       AND p.unit_cost > 0
       {store_filter}
@@ -91,7 +92,8 @@ WITH line_margins AS (
         FROM hospitals.xanalife_clean.inventory_stores
         GROUP BY id
     ) st ON p.store_id = st.id
-    WHERE TRY_TO_TIMESTAMP(s.created_at) >= '2025-09-01'
+    WHERE TRY_TO_TIMESTAMP(s.created_at) >= {start_date}
+      AND TRY_TO_TIMESTAMP(s.created_at) <= {end_date}
       AND s.status != 'canceled'
       AND p.unit_cost > 0
       {store_filter}
@@ -127,7 +129,8 @@ WITH line_margins AS (
     FROM hospitals.xanalife_clean.evaluation_pos_sale_details s
     JOIN hospitals.xanalife_clean.inventory_store_products p
         ON s.store_product_id = p.id
-    WHERE TRY_TO_TIMESTAMP(s.created_at) >= '2025-09-01'
+    WHERE TRY_TO_TIMESTAMP(s.created_at) >= {start_date}
+      AND TRY_TO_TIMESTAMP(s.created_at) <= {end_date}
       AND s.status != 'canceled'
       AND p.unit_cost > 0
       {store_filter}
@@ -148,7 +151,7 @@ GROUP BY 1
 ORDER BY 1
 """
 
-
+# Sale-level breakdown of every transaction that sold below cost.
 SQL_LOSS_TRANSACTIONS = """
 WITH sale_margins AS (
     SELECT
@@ -162,7 +165,8 @@ WITH sale_margins AS (
     FROM hospitals.xanalife_clean.evaluation_pos_sale_details s
     JOIN hospitals.xanalife_clean.inventory_store_products p
         ON s.store_product_id = p.id
-    WHERE TRY_TO_TIMESTAMP(s.created_at) >= '2025-09-01'
+    WHERE TRY_TO_TIMESTAMP(s.created_at) >= {start_date}
+      AND TRY_TO_TIMESTAMP(s.created_at) <= {end_date}
       AND s.status != 'canceled'
       AND p.unit_cost > 0
       {store_filter}
@@ -183,14 +187,16 @@ ORDER BY margin_pct
 
 # ── Analyses registry ──────────────────────────────────────────────────────────
 
-def get_analyses(store_names=None):
-    sf  = _store_clause(store_names)       # IN subquery for filter-only queries
-    bsf = _by_store_clause(store_names)    # AND st.name IN (...) for by-store
+def get_analyses(store_names=None, start_date='2025-09-01', end_date='2026-03-31'):
+    sf  = _store_clause(store_names)
+    bsf = _by_store_clause(store_names)
+    sd  = f"'{start_date}'"
+    ed  = f"'{end_date}'"
     return [
-        ("MVaR — Overall",      SQL_MVAR_OVERALL.format(store_filter=sf)),
-        ("MVaR — By Store",     SQL_MVAR_BY_STORE.format(store_filter=bsf)),
-        ("MVaR — Distribution", SQL_MVAR_DISTRIBUTION.format(store_filter=sf)),
-        ("Loss Transactions",   SQL_LOSS_TRANSACTIONS.format(store_filter=sf)),
+        ("MVaR — Overall",       SQL_MVAR_OVERALL.format(store_filter=sf, start_date=sd, end_date=ed)),
+        ("MVaR — By Store",      SQL_MVAR_BY_STORE.format(store_filter=bsf, start_date=sd, end_date=ed)),
+        ("MVaR — Distribution",  SQL_MVAR_DISTRIBUTION.format(store_filter=sf, start_date=sd, end_date=ed)),
+        ("Loss Transactions",    SQL_LOSS_TRANSACTIONS.format(store_filter=sf, start_date=sd, end_date=ed)),
     ]
 
 ANALYSES = get_analyses()

--- a/analytics_app/dashboards/xanalife/scripts/overview_analysis.py
+++ b/analytics_app/dashboards/xanalife/scripts/overview_analysis.py
@@ -24,16 +24,15 @@ def _store_clause(store_names, pos_col="pos.store_product_id"):
 
 
 # ── SQL templates ──────────────────────────────────────────────────────────────
-# Revenue + Stockout + Operating Margin: filterable via IN subquery — no fan-out.
+# Revenue + Operating Margin: filterable via IN subquery — no fan-out.
 # Invoices, Loyalty: not filterable (no store linkage).
 
-# Original structure preserved — no inventory_stores join in the main body.
-# {store_filter} uses IN subquery so no extra rows are introduced.
 SQL_REVENUE_SUMMARY = """
 WITH max_month AS (
     SELECT DATE_TRUNC('month', MAX(TRY_TO_TIMESTAMP(pos.created_at))) AS latest_month
     FROM hospitals.xanalife_clean.evaluation_pos_sale_details pos
-    WHERE TRY_TO_TIMESTAMP(pos.created_at) >= '2025-09-01'
+    WHERE TRY_TO_TIMESTAMP(pos.created_at) >= {start_date}
+      AND TRY_TO_TIMESTAMP(pos.created_at) <= {end_date}
       {store_filter}
 )
 SELECT
@@ -47,7 +46,8 @@ SELECT
                    THEN pos.amount ELSE 0 END), 0)                                     AS revenue_last_month,
     (SELECT latest_month FROM max_month)                                               AS latest_data_month
 FROM hospitals.xanalife_clean.evaluation_pos_sale_details pos
-WHERE TRY_TO_TIMESTAMP(pos.created_at) >= '2025-09-01'
+WHERE TRY_TO_TIMESTAMP(pos.created_at) >= {start_date}
+  AND TRY_TO_TIMESTAMP(pos.created_at) <= {end_date}
   {store_filter}
 """
 
@@ -71,7 +71,8 @@ WITH line_margins AS (
     FROM hospitals.xanalife_clean.evaluation_pos_sale_details pos
     JOIN hospitals.xanalife_clean.inventory_store_products sp
         ON pos.store_product_id = sp.id
-    WHERE TRY_TO_TIMESTAMP(pos.created_at) >= '2025-09-01'
+    WHERE TRY_TO_TIMESTAMP(pos.created_at) >= {start_date}
+      AND TRY_TO_TIMESTAMP(pos.created_at) <= {end_date}
       AND pos.status != 'canceled'
       AND sp.unit_cost > 0
       {store_filter}
@@ -85,7 +86,6 @@ WHERE revenue > 0
 """
 
 # COUNT(DISTINCT s.product) handles any fan-out from the product_id join.
-# Store filter uses IN subquery on product_id space.
 SQL_STOCKOUT_COUNT = """
 SELECT COUNT(DISTINCT s.product) AS products_at_zero_stock
 FROM hospitals.xanalife_clean.inventory_inventory_stocks s
@@ -110,7 +110,8 @@ WITH deduped AS (
         MIN(TRY_TO_NUMBER(amount))  AS amount,
         MIN(TRY_TO_NUMBER(balance)) AS balance
     FROM hospitals.xanalife_clean.finance_invoices
-    WHERE TRY_TO_TIMESTAMP(created_at) >= '2025-09-01'
+    WHERE TRY_TO_TIMESTAMP(created_at) >= {start_date}
+      AND TRY_TO_TIMESTAMP(created_at) <= {end_date}
       AND deleted_at IS NULL
       AND TRY_TO_NUMBER(balance) > 0
     GROUP BY id
@@ -122,6 +123,8 @@ SELECT
 FROM deduped
 """
 
+# Sep/Oct 2025 contain bulk-imported historical points (not organic activity).
+# loyalty_start is floored to 2025-11-01 inside get_analyses() — passed as {loyalty_start}.
 SQL_LOYALTY_SUMMARY = """
 SELECT
     SUM(CASE WHEN LOWER(type) = 'earned'   THEN points ELSE 0 END) AS total_earned,
@@ -129,16 +132,22 @@ SELECT
     SUM(CASE WHEN LOWER(type) = 'redeemed' THEN points ELSE 0 END) AS total_redeemed,
     COUNT(DISTINCT customer_id)                                     AS customers_with_points
 FROM hospitals.xanalife_clean.points
-WHERE TRY_TO_TIMESTAMP(created_at) >= '2025-09-01'
+WHERE TRY_TO_TIMESTAMP(created_at) >= {loyalty_start}
+  AND TRY_TO_TIMESTAMP(created_at) <= {end_date}
+  AND type IS NOT NULL AND TRIM(type) != ''
 """
 
 
 # ── Analyses registry ──────────────────────────────────────────────────────────
 
-def get_analyses(store_names=None):
+def get_analyses(store_names=None, start_date='2025-09-01', end_date='2026-03-31'):
     sf = _store_clause(store_names, pos_col="pos.store_product_id")
+    sd = f"'{start_date}'"
+    ed = f"'{end_date}'"
+    # Sep/Oct 2025 are bulk historical imports — loyalty always starts Nov 2025 minimum
+    loyalty_raw   = '2025-11-01' if start_date < '2025-11-01' else start_date
+    loyalty_start = f"'{loyalty_raw}'"
 
-    # Stockout uses product_id space — different placeholder name
     if store_names:
         names = ", ".join(f"'{n}'" for n in store_names)
         stockout_filter = f"AND st2.name IN ({names})"
@@ -146,12 +155,12 @@ def get_analyses(store_names=None):
         stockout_filter = ""
 
     return [
-        ("Revenue Summary",  SQL_REVENUE_SUMMARY.format(store_filter=sf)),
-        ("Revenue Trend",    SQL_REVENUE_TREND.format(store_filter=sf)),
-        ("Stockout Count",   SQL_STOCKOUT_COUNT.format(store_name_filter=stockout_filter)),
-        ("Invoices Summary", SQL_INVOICES_SUMMARY),
-        ("Loyalty Summary",  SQL_LOYALTY_SUMMARY),
-        ("Operating Margin", SQL_OPERATING_MARGIN.format(store_filter=sf)),
+        ("Revenue Summary",   SQL_REVENUE_SUMMARY.format(store_filter=sf, start_date=sd, end_date=ed)),
+        ("Revenue Trend",     SQL_REVENUE_TREND.format(store_filter=sf)),
+        ("Stockout Count",    SQL_STOCKOUT_COUNT.format(store_name_filter=stockout_filter)),
+        ("Invoices Summary",  SQL_INVOICES_SUMMARY.format(start_date=sd, end_date=ed)),
+        ("Loyalty Summary",   SQL_LOYALTY_SUMMARY.format(loyalty_start=loyalty_start, end_date=ed)),
+        ("Operating Margin",  SQL_OPERATING_MARGIN.format(store_filter=sf, start_date=sd, end_date=ed)),
     ]
 
 ANALYSES = get_analyses()

--- a/analytics_app/dashboards/xanalife/scripts/sales_analysis.py
+++ b/analytics_app/dashboards/xanalife/scripts/sales_analysis.py
@@ -52,7 +52,8 @@ SELECT
     COUNT(DISTINCT pos.sale_id)                          AS transactions,
     SUM(pos.amount)                                      AS daily_revenue
 FROM hospitals.xanalife_clean.evaluation_pos_sale_details pos
-WHERE TRY_TO_TIMESTAMP(pos.created_at) >= '2025-09-01'
+WHERE TRY_TO_TIMESTAMP(pos.created_at) >= {start_date}
+  AND TRY_TO_TIMESTAMP(pos.created_at) <= {end_date}
   {store_filter}
 GROUP BY 1
 ORDER BY 1
@@ -65,7 +66,8 @@ WITH basket AS (
         COUNT(*)        AS items,
         SUM(pos.amount) AS basket_value
     FROM hospitals.xanalife_clean.evaluation_pos_sale_details pos
-    WHERE TRY_TO_TIMESTAMP(pos.created_at) >= '2025-09-01'
+    WHERE TRY_TO_TIMESTAMP(pos.created_at) >= {start_date}
+      AND TRY_TO_TIMESTAMP(pos.created_at) <= {end_date}
       {store_filter}
     GROUP BY pos.sale_id
 )
@@ -86,7 +88,8 @@ SQL_BASKET_TOP_SINGLE_PRODUCTS = """
 WITH basket AS (
     SELECT pos.sale_id, COUNT(*) AS items
     FROM hospitals.xanalife_clean.evaluation_pos_sale_details pos
-    WHERE TRY_TO_TIMESTAMP(pos.created_at) >= '2025-09-01'
+    WHERE TRY_TO_TIMESTAMP(pos.created_at) >= {start_date}
+      AND TRY_TO_TIMESTAMP(pos.created_at) <= {end_date}
       {store_filter}
     GROUP BY pos.sale_id
 )
@@ -100,6 +103,7 @@ JOIN hospitals.xanalife_clean.inventory_store_products sp
 JOIN basket b
     ON b.sale_id = pos.sale_id AND b.items = 1
 WHERE sp.product_name IS NOT NULL
+  AND sp.product_category != 1887
   {store_filter}
 GROUP BY sp.product_name
 ORDER BY times_bought_alone DESC
@@ -122,7 +126,8 @@ WITH basket AS (
         FROM hospitals.xanalife_clean.inventory_stores
         GROUP BY id
     ) st ON sp.store_id = st.id
-    WHERE TRY_TO_TIMESTAMP(pos.created_at) >= '2025-09-01'
+    WHERE TRY_TO_TIMESTAMP(pos.created_at) >= {start_date}
+      AND TRY_TO_TIMESTAMP(pos.created_at) <= {end_date}
       {store_filter}
     GROUP BY pos.sale_id, st.name
 )
@@ -153,7 +158,8 @@ SELECT
     COUNT(DISTINCT pos.sale_id)                      AS transactions,
     ROUND(SUM(pos.amount), 0)                        AS revenue
 FROM hospitals.xanalife_clean.evaluation_pos_sale_details pos
-WHERE TRY_TO_TIMESTAMP(pos.created_at) >= '2025-09-01'
+WHERE TRY_TO_TIMESTAMP(pos.created_at) >= {start_date}
+  AND TRY_TO_TIMESTAMP(pos.created_at) <= {end_date}
   {store_filter}
 GROUP BY 1, 2, 3
 ORDER BY day_num, hour_of_day
@@ -183,7 +189,8 @@ SELECT
     COUNT(DISTINCT pos.sale_id) AS transactions
 FROM hospitals.xanalife_clean.evaluation_pos_sale_details pos
 JOIN sp_store ss ON pos.store_product_id = ss.store_product_id
-WHERE TRY_TO_TIMESTAMP(pos.created_at) >= '2025-09-01'
+WHERE TRY_TO_TIMESTAMP(pos.created_at) >= {start_date}
+  AND TRY_TO_TIMESTAMP(pos.created_at) <= {end_date}
   {store_filter}
 GROUP BY ss.store_name, ss.store_code
 ORDER BY revenue DESC
@@ -219,7 +226,8 @@ ranked AS (
         ) AS rn
     FROM hospitals.xanalife_clean.evaluation_pos_sale_details pos
     JOIN sp_store ss ON pos.store_product_id = ss.store_product_id
-    WHERE TRY_TO_TIMESTAMP(pos.created_at) >= '2025-09-01'
+    WHERE TRY_TO_TIMESTAMP(pos.created_at) >= {start_date}
+      AND TRY_TO_TIMESTAMP(pos.created_at) <= {end_date}
       AND ss.product_name IS NOT NULL
       {store_filter}
     GROUP BY ss.location, ss.product_name, ss.product_category
@@ -257,7 +265,8 @@ loc_revenue AS (
         ROUND(SUM(pos.amount), 0) AS revenue
     FROM hospitals.xanalife_clean.evaluation_pos_sale_details pos
     JOIN sp_store ss ON pos.store_product_id = ss.store_product_id
-    WHERE TRY_TO_TIMESTAMP(pos.created_at) >= '2025-09-01'
+    WHERE TRY_TO_TIMESTAMP(pos.created_at) >= {start_date}
+      AND TRY_TO_TIMESTAMP(pos.created_at) <= {end_date}
       AND ss.product_name IS NOT NULL
       {store_filter}
     GROUP BY ss.location, ss.product_name, ss.product_category
@@ -287,18 +296,20 @@ LIMIT 25
 
 # ── Analyses registry ──────────────────────────────────────────────────────────
 
-def get_analyses(store_names=None):
-    sf  = _store_clause(store_names)       # IN subquery — for total-aggregate queries
-    bsf = _by_store_clause(store_names)    # AND st.name IN (...) — for by-store queries
+def get_analyses(store_names=None, start_date='2025-09-01', end_date='2026-03-31'):
+    sf  = _store_clause(store_names)
+    bsf = _by_store_clause(store_names)
+    sd  = f"'{start_date}'"
+    ed  = f"'{end_date}'"
     return [
-        ("Daily Revenue",              SQL_DAILY_REVENUE.format(store_filter=sf)),
-        ("Basket Summary",             SQL_BASKET_SUMMARY.format(store_filter=sf)),
-        ("Top Single-Item Products",   SQL_BASKET_TOP_SINGLE_PRODUCTS.format(store_filter=sf)),
-        ("Basket by Store",            SQL_BASKET_BY_STORE.format(store_filter=bsf)),
-        ("Peak Revenue Heatmap",       SQL_PEAK_HEATMAP.format(store_filter=sf)),
-        ("Revenue by Store",           SQL_REVENUE_BY_STORE.format(store_filter=sf)),
-        ("Top Products by Location",   SQL_TOP_PRODUCTS_BY_LOCATION.format(store_filter=sf)),
-        ("Location Opportunity",       SQL_LOCATION_OPPORTUNITY.format(store_filter=sf)),
+        ("Daily Revenue",              SQL_DAILY_REVENUE.format(store_filter=sf, start_date=sd, end_date=ed)),
+        ("Basket Summary",             SQL_BASKET_SUMMARY.format(store_filter=sf, start_date=sd, end_date=ed)),
+        ("Top Single-Item Products",   SQL_BASKET_TOP_SINGLE_PRODUCTS.format(store_filter=sf, start_date=sd, end_date=ed)),
+        ("Basket by Store",            SQL_BASKET_BY_STORE.format(store_filter=bsf, start_date=sd, end_date=ed)),
+        ("Peak Revenue Heatmap",       SQL_PEAK_HEATMAP.format(store_filter=sf, start_date=sd, end_date=ed)),
+        ("Revenue by Store",           SQL_REVENUE_BY_STORE.format(store_filter=sf, start_date=sd, end_date=ed)),
+        ("Top Products by Location",   SQL_TOP_PRODUCTS_BY_LOCATION.format(store_filter=sf, start_date=sd, end_date=ed)),
+        ("Location Opportunity",       SQL_LOCATION_OPPORTUNITY.format(store_filter=sf, start_date=sd, end_date=ed)),
     ]
 
 ANALYSES = get_analyses()

--- a/analytics_app/dashboards/xanalife/scripts/scr_analysis.py
+++ b/analytics_app/dashboards/xanalife/scripts/scr_analysis.py
@@ -35,8 +35,7 @@ def _store_clause(store_names, dis_col="d.store_product_id"):
 
 # ── SQL templates ──────────────────────────────────────────────────────────────
 # All SCR queries use dispensing (d.store_product_id) as the fact join point.
-# Store filter uses IN subquery — no direct inventory_stores join in the weekly CTE.
-# Previous hardcoded pharmacy exclusion removed; Division filter drives store selection.
+# Retail category (1887) excluded — it is supermarket retail, not FMCG dispensing.
 
 SQL_SCR_SUMMARY = """
 WITH weekly AS (
@@ -49,8 +48,10 @@ WITH weekly AS (
     FROM hospitals.xanalife_clean.inventory_inventory_dispensing d
     JOIN hospitals.xanalife_clean.inventory_store_products sp
         ON d.store_product_id = sp.id
-    WHERE TRY_TO_TIMESTAMP(d.created_at) >= '2025-09-01'
+    WHERE TRY_TO_TIMESTAMP(d.created_at) >= {start_date}
+      AND TRY_TO_TIMESTAMP(d.created_at) <= {end_date}
       AND sp.product_name IS NOT NULL
+      AND sp.product_category != 1887
       {store_filter}
     GROUP BY 1, 2, 3, 4
 ),
@@ -155,8 +156,10 @@ WITH weekly AS (
     FROM hospitals.xanalife_clean.inventory_inventory_dispensing d
     JOIN hospitals.xanalife_clean.inventory_store_products sp
         ON d.store_product_id = sp.id
-    WHERE TRY_TO_TIMESTAMP(d.created_at) >= '2025-09-01'
+    WHERE TRY_TO_TIMESTAMP(d.created_at) >= {start_date}
+      AND TRY_TO_TIMESTAMP(d.created_at) <= {end_date}
       AND sp.product_name IS NOT NULL
+      AND sp.product_category != 1887
       {store_filter}
     GROUP BY 1, 2, 3
 ),
@@ -188,6 +191,8 @@ ORDER BY 2 DESC
 LIMIT 10
 """
 
+# Depletion uses last-28-days velocity — start is intentionally dynamic (DATEADD).
+# {end_date} caps dispensing to the data window only.
 SQL_DEPLETION_RISK = """
 WITH velocity AS (
     SELECT
@@ -200,7 +205,9 @@ WITH velocity AS (
     JOIN hospitals.xanalife_clean.inventory_store_products sp
         ON d.store_product_id = sp.id
     WHERE TRY_TO_TIMESTAMP(d.created_at) >= DATEADD('day', -28, CURRENT_DATE())
+      AND TRY_TO_TIMESTAMP(d.created_at) <= {end_date}
       AND sp.product_name IS NOT NULL
+      AND sp.product_category != 1887
       {store_filter}
     GROUP BY 1, 2, 3
 ),
@@ -251,12 +258,14 @@ LIMIT 50
 
 # ── Analyses registry ──────────────────────────────────────────────────────────
 
-def get_analyses(store_names=None):
+def get_analyses(store_names=None, start_date='2025-09-01', end_date='2026-03-31'):
     sf = _store_clause(store_names, dis_col="d.store_product_id")
+    sd = f"'{start_date}'"
+    ed = f"'{end_date}'"
     return [
-        ("SCR Summary — Stockouts + Top Substitute",  SQL_SCR_SUMMARY.format(store_filter=sf)),
-        ("Category Exposure — Stockouts by Category", SQL_CATEGORY_EXPOSURE.format(store_filter=sf)),
-        ("Depletion Risk — Days Until Stockout",      SQL_DEPLETION_RISK.format(store_filter=sf)),
+        ("SCR Summary — Stockouts + Top Substitute",  SQL_SCR_SUMMARY.format(store_filter=sf, start_date=sd, end_date=ed)),
+        ("Category Exposure — Stockouts by Category", SQL_CATEGORY_EXPOSURE.format(store_filter=sf, start_date=sd, end_date=ed)),
+        ("Depletion Risk — Days Until Stockout",      SQL_DEPLETION_RISK.format(store_filter=sf, end_date=ed)),
     ]
 
 ANALYSES = get_analyses()


### PR DESCRIPTION
- Sidebar: replace multiselect with All Stores checkbox + per-store checkboxes
- Sidebar: add From/To month selector (Sep 2025 – Mar 2026) with validation
- filter_key now includes date range tuple — cache invalidates on date change
- All 5 analysis modules updated: get_analyses() accepts start_date, end_date
- Overview c2 KPI swapped from month revenue to Revenue at Risk (SCR)
- SCR summary pre-loaded on Overview page for Revenue at Risk card
- Cash Integrity: migrated from static ANALYSES list to get_analyses(start, end)
- SCR: retail category 1887 excluded from dispensing queries
- Sales: retail category 1887 excluded from Products Most Often Bought Alone
- Cross-location monthly upside now calculated from selected date range