### PR TITLE
KSH inventory intelligence: data-anchored ref_date, digest migration, crash & UI fixes

### DIFF
--- a/analytics_app/dashboards/ksh/inventory_intelligence/intelligence/priority_scorer.py
+++ b/analytics_app/dashboards/ksh/inventory_intelligence/intelligence/priority_scorer.py
@@ -43,8 +43,8 @@ def clinical_priority(
     therapeutic_subclass: str,
 ) -> str:
     """Classify a product's clinical criticality tier."""
-    subclass = (therapeutic_subclass or "").strip()
-    t_class = (therapeutic_class or "").strip()
+    subclass = (therapeutic_subclass if isinstance(therapeutic_subclass, str) else "").strip()
+    t_class  = (therapeutic_class    if isinstance(therapeutic_class,    str) else "").strip()
 
     if subclass in CRITICAL_THERAPEUTIC_SUBCLASSES:
         return PRIORITY_CRITICAL

--- a/analytics_app/dashboards/ksh/inventory_intelligence/utils/components.py
+++ b/analytics_app/dashboards/ksh/inventory_intelligence/utils/components.py
@@ -30,7 +30,14 @@ section[data-testid="stSidebarNav"],
 [data-testid="stSidebarNavItems"],
 [data-testid="stSidebarNavSeparator"] { display: none !important; }
 
-.main .block-container { padding-top: 0.5rem; }
+/* Use more of the viewport — trim Streamlit's default side/top whitespace */
+.main .block-container,
+[data-testid="stMainBlockContainer"],
+[data-testid="stAppViewBlockContainer"] {
+    max-width: 1600px;
+    /* top clears Streamlit's 60px fixed header so the page title stays visible */
+    padding: 4.5rem 2.5rem 3rem;
+}
 
 /* ── Page header ───────────────────────────────────── */
 .page-header {
@@ -68,16 +75,16 @@ section[data-testid="stSidebarNav"],
     padding: 14px 14px 12px;
 }
 .kpi-label {
-    font-size: 11px;
+    font-size: 12px;
     font-weight: 600;
     text-transform: uppercase;
-    letter-spacing: 0.06em;
+    letter-spacing: 0.05em;
     color: #9CA3AF;
     margin-bottom: 6px;
     line-height: 1.4;              /* allow wrapping — no truncation */
 }
 .kpi-value {
-    font-size: 26px;
+    font-size: 28px;
     font-weight: 700;
     color: #111827;
     line-height: 1.1;
@@ -247,26 +254,26 @@ section[data-testid="stSidebarNav"],
 }
 .stat-item:last-child { border-right: none; }
 .stat-label {
-    font-size: 10px;
+    font-size: 11.5px;
     font-weight: 700;
     text-transform: uppercase;
-    letter-spacing: 0.07em;
+    letter-spacing: 0.05em;
     color: #9CA3AF;
-    margin-bottom: 4px;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
+    margin-bottom: 5px;
+    line-height: 1.3;
+    min-height: 2.3em;            /* reserve 2 lines so values stay aligned */
+    white-space: normal;          /* wrap the full label instead of truncating */
 }
 .stat-value {
-    font-size: 24px;
+    font-size: 27px;
     font-weight: 700;
     color: #111827;
     line-height: 1.1;
 }
 .stat-hint {
-    font-size: 11px;
+    font-size: 12px;
     font-weight: 600;
-    margin-top: 2px;
+    margin-top: 3px;
 }
 
 /* ── AI Decision cards ─────────────────────────────────── */

--- a/analytics_app/dashboards/ksh/inventory_intelligence/utils/facility.py
+++ b/analytics_app/dashboards/ksh/inventory_intelligence/utils/facility.py
@@ -23,9 +23,11 @@ class FacilityMeta:
     alert_count_key: str   # Session-state key for badge on landing page
     # Snowflake table overrides (None = use global default)
     batch_purchases_table: Optional[str] = None
-    # For historical facilities: last date with data (YYYY-MM-DD).
-    # All time-windowed queries anchor to this date instead of CURRENT_DATE
-    # so that lookback windows (e.g. -90 days) actually find records.
+    # Fixed anchor date (YYYY-MM-DD) for all time-windowed queries. Set this
+    # only to pin a facility to a hard historical cutoff. When left None, the
+    # anchor is resolved dynamically to MAX(dispensed_at) in the facility's
+    # data, so lookback windows (e.g. -90 days) always find real records even
+    # when the data lags the calendar date.
     data_end_date: Optional[str] = None
     # Clinical go-live date (YYYY-MM-DD). Records before this date are
     # test/training data and should be excluded from patient-facing analytics.
@@ -41,7 +43,7 @@ FACILITIES: dict[str, FacilityMeta] = {
         date_range="Sep 2024 – Present",
         alert_count_key="ksh_alert_count",
         batch_purchases_table=None,  # no batch table; SOH-jump detection used
-        data_end_date=None,          # live — use CURRENT_DATE
+        data_end_date=None,          # dynamic — anchor to MAX(dispensed_at) in data
         go_live_date="2024-09-01",   # clinical go-live; pre-date records are test data
     ),
 
@@ -90,16 +92,50 @@ def sql_go_live_filter(fac: FacilityMeta, date_col: str = "dispensed_at") -> str
     return ""
 
 
+@st.cache_data(ttl=3600, show_spinner=False)
+def _resolve_max_data_date(schema: str) -> Optional[str]:
+    """
+    Most recent dispensing date in a facility's data, as an ISO 'YYYY-MM-DD'
+    string. Returns None if it can't be resolved (empty data or query error).
+
+    Capped at CURRENT_DATE so a stray future-dated record can't push the
+    anchor past today. Cached for 1 hour alongside the rest of the query layer.
+    """
+    try:
+        from utils.snowflake_conn import run_query
+        df = run_query(f"""
+            SELECT TO_VARCHAR(
+                       LEAST(MAX(dispensed_at)::DATE, CURRENT_DATE),
+                       'YYYY-MM-DD') AS max_date
+            FROM HOSPITALS.REPORTING.FACT_DISPENSING
+            WHERE source_schema = '{schema}'
+        """)
+        if not df.empty and df.iloc[0, 0]:
+            return str(df.iloc[0, 0])
+    except Exception:
+        pass
+    return None
+
+
 def sql_ref_date(fac: FacilityMeta) -> str:
     """
     Return the SQL date expression to use as the 'current date' anchor for
     all time-windowed queries.
 
-    - Live facilities  → CURRENT_DATE  (real-time)
-    - Historical facilities → literal date string anchored to the last day
-      of data, so that lookback windows (e.g. -90 days) find real records
-      instead of returning empty.
+    The data is not live-streamed — the newest dispensing record can lag the
+    real calendar date by weeks or months. Anchoring lookback windows (e.g.
+    -90 days) to CURRENT_DATE would then find no records and blank out
+    Patient Risk, Stockout Watch and the briefing patient monitor. So we
+    anchor to the most recent dispensing date in the facility's own data.
+
+    - Explicit data_end_date set → use it (fixed historical facilities).
+    - Otherwise                  → resolve MAX(dispensed_at) from the data.
+    - On any failure             → fall back to CURRENT_DATE.
+
+    Returns a plain quoted ISO literal ('YYYY-MM-DD') so parse_ref_date() and
+    downstream `.strip("'")` handling keep working unchanged.
     """
-    if fac.is_live or fac.data_end_date is None:
-        return "CURRENT_DATE"
-    return f"'{fac.data_end_date}'::DATE"
+    if fac.data_end_date:
+        return f"'{fac.data_end_date}'"
+    resolved = _resolve_max_data_date(fac.schema)
+    return f"'{resolved}'" if resolved else "CURRENT_DATE"

--- a/analytics_app/dashboards/ksh/inventory_intelligence/utils/notifier.py
+++ b/analytics_app/dashboards/ksh/inventory_intelligence/utils/notifier.py
@@ -1,46 +1,14 @@
-"""
-Phase 2.5 — Daily Digest delivery.
-
-Sends a daily email digest (top insights + key KPIs + dashboard link) via SMTP.
-WhatsApp delivery is deferred pending Meta Business API approval.
-
-Configuration (add to .env):
-    NOTIFY_EMAIL_TO      — recipient address(es), comma-separated
-    NOTIFY_EMAIL_FROM    — sender address (e.g. alerts@afya.ai)
-    SMTP_HOST            — SMTP server hostname
-    SMTP_PORT            — SMTP port (default 587)
-    SMTP_USER            — SMTP login username
-    SMTP_PASSWORD        — SMTP login password
-    DASHBOARD_URL        — public URL of the dashboard (for the CTA button)
-
-Usage (standalone script or cron):
-    from utils.notifier import send_daily_digest
-    send_daily_digest(
-        facility_name="Facility Name",
-        insights=insight_rows,          # List[InsightRow] from insight_engine.detect_all()
-        kpi=kpi_dict,                   # from get_kpi_summary()
-        order_count=12,                 # ORDER_NOW count from score_all()
-        patient_risk_count=8,           # total_patients_at_risk from get_patient_risk_totals()
-    )
-
-Design principles (from ROADMAP):
-  - SMTP credentials loaded from .env — never hard-coded
-  - LLM never touches raw data — all numbers pre-computed before this call
-  - Sends at most once per facility per calendar day (idempotency guard via a local
-    date-stamp file under /tmp — lightweight, no database required)
-"""
-
 from __future__ import annotations
 
 import html
 import os
-import smtplib
 import tempfile
 from datetime import date
-from email.mime.multipart import MIMEMultipart
-from email.mime.text import MIMEText
 from pathlib import Path
 from typing import List, Optional, TYPE_CHECKING
+
+from django.conf import settings as dj_settings
+from django.core.mail import EmailMultiAlternatives
 
 if TYPE_CHECKING:
     from intelligence.insight_engine import InsightRow
@@ -50,6 +18,30 @@ if TYPE_CHECKING:
 
 def _env(key: str, default: str = "") -> str:
     return os.environ.get(key, default).strip()
+
+
+def _ensure_django_email_configured() -> None:
+
+    if dj_settings.configured:
+        return
+    import django
+    if os.environ.get("DJANGO_SETTINGS_MODULE"):
+        django.setup()
+    else:
+        dj_settings.configure(
+            INSTALLED_APPS=[],
+            EMAIL_BACKEND="django.core.mail.backends.smtp.EmailBackend",
+            EMAIL_HOST=_env("EMAIL_HOST", "smtp.gmail.com"),
+            EMAIL_PORT=int(_env("EMAIL_PORT", "587")),
+            EMAIL_USE_TLS=_env("EMAIL_USE_TLS", "true").lower() != "false",
+            EMAIL_HOST_USER=_env("EMAIL_HOST_USER"),
+            EMAIL_HOST_PASSWORD=_env("EMAIL_HOST_PASSWORD"),
+            DEFAULT_FROM_EMAIL=_env("NOTIFY_EMAIL_FROM", "noreply@afyaanalytics.com"),
+        )
+
+
+def _default_sender() -> str:
+    return getattr(dj_settings, "DEFAULT_FROM_EMAIL", "noreply@afyaanalytics.com")
 
 
 # ── Idempotency guard ─────────────────────────────────────────────────────────
@@ -99,6 +91,43 @@ def _insight_block_html(row: "InsightRow") -> str:
     )
 
 
+_SEV_LABEL = {"CRITICAL": "AT PEAK", "HIGH": "APPROACHING", "MEDIUM": "WATCH"}
+_SEV_CHIP  = {
+    "CRITICAL": "background:#FEE2E2;color:#991B1B;border:1px solid #FECACA",
+    "HIGH":     "background:#FEF3C7;color:#92400E;border:1px solid #FDE68A",
+    "MEDIUM":   "background:#EFF6FF;color:#1E40AF;border:1px solid #BFDBFE",
+}
+
+
+def _seasonal_section_html(signals: list) -> str:
+    if not signals:
+        return ""
+    chips = ""
+    for s in sorted(signals, key=lambda x: {"CRITICAL": 0, "HIGH": 1, "MEDIUM": 2}.get(x.get("severity", "MEDIUM"), 2)):
+        sev     = str(s.get("severity", "MEDIUM")).upper()
+        lbl     = _SEV_LABEL.get(sev, sev)
+        style   = _SEV_CHIP.get(sev, _SEV_CHIP["MEDIUM"])
+        timing  = "at peak" if s.get("weeks_to_peak") == 0 else f"{s.get('weeks_to_peak')}w away"
+        uplift  = round((s.get("demand_multiplier", 1) - 1) * 100)
+        drugs   = s.get("drugs_at_risk", 0)
+        disease = html.escape(str(s.get("disease", "")))
+        chips += (
+            f'<span style="display:inline-block;border-radius:6px;padding:4px 10px;'
+            f'margin:0 6px 6px 0;font-size:11px;{style}">'
+            f'<span style="font-weight:700;font-size:10px">{lbl}</span>'
+            f'&nbsp;<span style="font-weight:600">{disease}</span>'
+            f'&nbsp;<span style="opacity:0.7">· {timing} · {drugs} drug{"s" if drugs != 1 else ""} · +{uplift}% demand</span>'
+            f'</span>'
+        )
+    return (
+        f'<tr><td style="padding:14px 28px 0">'
+        f'<div style="font-size:10px;font-weight:700;text-transform:uppercase;'
+        f'letter-spacing:0.07em;color:#9CA3AF;margin-bottom:6px">Seasonal demand signals</div>'
+        f'<div>{chips}</div>'
+        f'</td></tr>'
+    )
+
+
 def _build_html(
     facility_name: str,
     insights: List["InsightRow"],
@@ -108,6 +137,7 @@ def _build_html(
     dashboard_url: str,
     digest_date: date,
     clinical_alerts: Optional[List["InsightRow"]] = None,
+    seasonal_signals: Optional[list] = None,
 ) -> str:
     insight_blocks = "".join(_insight_block_html(r) for r in insights[:3])
     if not insight_blocks:
@@ -208,6 +238,9 @@ def _build_html(
           {insight_blocks}
         </td></tr>
 
+        <!-- Seasonal demand signals -->
+        {_seasonal_section_html(seasonal_signals or [])}
+
         <!-- Clinical alerts -->
         {clinical_section}
 
@@ -241,6 +274,7 @@ def _build_plaintext(
     dashboard_url: str,
     digest_date: date,
     clinical_alerts: Optional[List["InsightRow"]] = None,
+    seasonal_signals: Optional[list] = None,
 ) -> str:
     _kpi = {k.lower(): v for k, v in kpi.items()}
     stockouts = int(_kpi.get("active_stockouts", 0) or 0)
@@ -266,6 +300,15 @@ def _build_plaintext(
     if not insights:
         lines.append("  No critical insights today. Stock levels are healthy.")
 
+    if seasonal_signals:
+        lines += ["", "SEASONAL DEMAND SIGNALS"]
+        for s in seasonal_signals:
+            sev    = str(s.get("severity", "")).upper()
+            lbl    = _SEV_LABEL.get(sev, sev)
+            timing = "at peak" if s.get("weeks_to_peak") == 0 else f"{s.get('weeks_to_peak')}w away"
+            uplift = round((s.get("demand_multiplier", 1) - 1) * 100)
+            lines.append(f"  [{lbl}] {s.get('disease')} · {timing} · {s.get('drugs_at_risk')} drugs · +{uplift}% demand")
+
     if clinical_alerts:
         lines += ["", "CLINICAL ALERTS"]
         for i, row in enumerate(clinical_alerts[:5], 1):
@@ -290,6 +333,7 @@ def send_daily_digest(
     facility_slug: Optional[str] = None,
     force: bool = False,
     clinical_alerts: Optional[List["InsightRow"]] = None,
+    seasonal_signals: Optional[list] = None,
 ) -> bool:
     """
     Send the daily digest email.
@@ -297,65 +341,51 @@ def send_daily_digest(
     Args:
         facility_name:       Human-readable facility label (shown in email).
         insights:            Top insights from insight_engine.detect_all() (stockout/demand items).
-        kpi:                 KPI dict from get_kpi_summary() (keys case-insensitive).
+        kpi:                 KPI dict — use engine-derived counts for stock status fields.
         order_count:         Number of ORDER_NOW items from score_all().
         patient_risk_count:  Total patients at risk from get_patient_risk_totals().
         facility_slug:       Short identifier for idempotency stamp (default: lowered facility_name).
         force:               If True, bypass the once-per-day idempotency guard.
-        clinical_alerts:     R3 dead stock + R5 refill overdue InsightRows. Rendered as a
-                             dedicated "Clinical alerts" section below priority insights.
+        clinical_alerts:     R3 dead stock + R5 refill overdue InsightRows.
+        seasonal_signals:    _actionable_summaries from the briefing page seasonal engine.
 
     Returns:
-        True if email was sent, False if skipped (already sent today or config missing).
+        True if email was sent, False if skipped (already sent today or NOTIFY_EMAIL_TO unset).
 
     Raises:
-        smtplib.SMTPException on SMTP-level errors.
+        django.core.mail.BadHeaderError / smtplib.SMTPException on delivery errors.
     """
+    _ensure_django_email_configured()
+
     slug = (facility_slug or facility_name.lower().replace(" ", "_"))
 
     if not force and _already_sent_today(slug):
         return False
 
-    # Load SMTP config from environment
     recipients_raw = _env("NOTIFY_EMAIL_TO")
-    sender         = _env("NOTIFY_EMAIL_FROM")
-    smtp_host      = _env("SMTP_HOST")
-    smtp_port      = int(_env("SMTP_PORT", "587"))
-    smtp_user      = _env("SMTP_USER")
-    smtp_password  = _env("SMTP_PASSWORD")
     dashboard_url  = _env("DASHBOARD_URL")
 
-    if not (recipients_raw and sender and smtp_host and smtp_user and smtp_password):
-        # Config not set — silently skip (digest is optional)
+    if not recipients_raw:
         return False
 
     recipients = [r.strip() for r in recipients_raw.split(",") if r.strip()]
     if not recipients:
         return False
 
-    today = date.today()
+    today   = date.today()
+    sender  = _default_sender()
     subject = (
         f"[Afya] Daily digest — {facility_name} — "
         f"{len(insights)} insight{'s' if len(insights) != 1 else ''} · "
         f"{today.strftime('%d %b %Y')}"
     )
 
-    msg = MIMEMultipart("alternative")
-    msg["Subject"] = subject
-    msg["From"]    = sender
-    msg["To"]      = ", ".join(recipients)
+    plain     = _build_plaintext(facility_name, insights, kpi, order_count, patient_risk_count, dashboard_url, today, clinical_alerts=clinical_alerts, seasonal_signals=seasonal_signals)
+    html_body = _build_html(facility_name, insights, kpi, order_count, patient_risk_count, dashboard_url, today, clinical_alerts=clinical_alerts, seasonal_signals=seasonal_signals)
 
-    plain     = _build_plaintext(facility_name, insights, kpi, order_count, patient_risk_count, dashboard_url, today, clinical_alerts=clinical_alerts)
-    html_body = _build_html(facility_name, insights, kpi, order_count, patient_risk_count, dashboard_url, today, clinical_alerts=clinical_alerts)
-
-    msg.attach(MIMEText(plain, "plain"))
-    msg.attach(MIMEText(html_body, "html"))
-
-    with smtplib.SMTP(smtp_host, smtp_port) as server:
-        server.ehlo()
-        server.starttls()
-        server.login(smtp_user, smtp_password)
-        server.sendmail(sender, recipients, msg.as_string())
+    msg = EmailMultiAlternatives(subject, plain, sender, recipients)
+    msg.attach_alternative(html_body, "text/html")
+    msg.send()
 
     _mark_sent_today(slug)
     return True

--- a/analytics_app/dashboards/ksh/ksh_inventory_intelligence.py
+++ b/analytics_app/dashboards/ksh/ksh_inventory_intelligence.py
@@ -700,22 +700,31 @@ if page == "Today's Briefing":
             except Exception:
                 pass
             _pr_count = int(_pr_count_row.get("total_patients_at_risk", 0) or 0)
+            # Use engine-derived stock counts (same source as the briefing KPI strip)
+            # supplemented by SQL kpi for value/chronic fields.
+            _digest_kpi = {
+                "active_stockouts":       _engine_kpis["active_stockouts"],
+                "critical_count":         _engine_kpis["critical_count"],
+                "low_count":              _engine_kpis["low_count"],
+                "chronic_patients_active": kpi.get("CHRONIC_PATIENTS_ACTIVE") or kpi.get("chronic_patients_active", 0),
+            }
             with st.spinner("Sending digest…"):
                 try:
                     sent = send_daily_digest(
                         facility_name=fac.label,
                         insights=_insights,
-                        kpi=kpi,
+                        kpi=_digest_kpi,
                         order_count=_order_now_count,
                         patient_risk_count=_pr_count,
                         facility_slug=fac.schema,
                         force=True,
                         clinical_alerts=_novel_insights,
+                        seasonal_signals=_actionable_summaries or [],
                     )
                     if sent:
                         st.success("Digest sent ✓")
                     else:
-                        st.warning("Email not configured — add NOTIFY_EMAIL_TO, SMTP_HOST, etc. to .env")
+                        st.warning("Email not configured — add NOTIFY_EMAIL_TO and EMAIL_HOST_USER to .env")
                 except Exception as _e:
                     st.error(f"Send failed: {_e}")
 
@@ -1342,7 +1351,12 @@ elif page == "Dead Stock":
     _ds_h: pd.DataFrame = pd.DataFrame()
     _anchor_ds = (
         pd.Timestamp(_ref_date.strip("'"))
-        if _ref_date != "CURRENT_DATE" else pd.Timestamp.now().normalize()
+        if _ref_date != "CURRENT_DATE"
+        else (
+            pd.to_datetime(_ds_history["dispensed_at"]).max().normalize()
+            if not _ds_history.empty and "dispensed_at" in _ds_history.columns
+            else pd.Timestamp.now().normalize()
+        )
     )
 
     if not _ds_history.empty:
@@ -1410,7 +1424,6 @@ elif page == "Dead Stock":
     # Months-to-clear: uses RECENT demand rate, not peak — shows real clearance horizon.
 
     _root_cause_map:       dict = {}
-    _months_clear_map:     dict = {}   # at recent demand rate
     _recent_monthly_map:   dict = {}
     _smoothed_peak_map:    dict = {}
 
@@ -1434,8 +1447,16 @@ elif page == "Dead Stock":
             _smoothed_peak = float(_top3.mean()) if not _top3.empty else 0.0
             _smoothed_peak_map[_drug] = _smoothed_peak
 
-            _recent_qty     = float(_grp[_grp["DISPENSED_AT"] >= _cutoff_90]["QUANTITY_DISPENSED"].sum())
-            _recent_monthly = _recent_qty / 3.0
+            _recent_qty = float(_grp[_grp["DISPENSED_AT"] >= _cutoff_90]["QUANTITY_DISPENSED"].sum())
+
+            # Divide by the window the drug was actually active, not the full 90 days.
+            # A drug idle for N days was only dispensed during the first (90-N) days of the
+            # window — dividing by 3 months deflates the rate and inflates months-to-clear.
+            # Floor at 14 days (~a fortnight) to avoid runaway extrapolation from a single
+            # dispensing event in the last few days before a drug went idle.
+            _min_idle       = int(_days_idle_lookup.get(_drug, 0))
+            _active_days    = max(14, 90 - _min_idle)
+            _recent_monthly = _recent_qty / (_active_days / 30.0)
             _recent_monthly_map[_drug] = _recent_monthly
 
             _recent_itr     = _ds_recent_itr_map.get(_drug, 0.0)
@@ -1454,13 +1475,14 @@ elif page == "Dead Stock":
             else:
                 _root_cause_map[_drug] = "Over-ordered"
 
-    # Months to clear at RECENT demand rate (realistic) and at smoothed peak (best case)
+    # Months to clear computed per-row so different SOH values for the same canonical name
+    # each get their own figure rather than the last row overwriting the map.
     if not dead_df.empty and "CURRENT_SOH" in dead_df.columns:
-        for _, _r in dead_df.iterrows():
-            _n   = _r.get("CANONICAL_NAME")
-            _soh = float(_r.get("CURRENT_SOH") or 0)
-            _rm  = _recent_monthly_map.get(_n, 0)
-            _months_clear_map[_n] = round(_soh / _rm, 1) if _rm > 0 and _soh > 0 else None
+        def _calc_months(row):
+            _soh = float(row.get("CURRENT_SOH") or 0)
+            _rm  = _recent_monthly_map.get(row.get("CANONICAL_NAME"), 0)
+            return round(_soh / _rm, 1) if _rm > 0 and _soh > 0 else None
+        dead_df["MONTHS_TO_CLEAR"] = dead_df.apply(_calc_months, axis=1)
 
     # Items whose root cause history comes from before the 730d window are "Dormant"
     # (dead stock query has no date cap on MAX(dispensed_at); _ds_h only covers 730d)
@@ -1531,7 +1553,23 @@ elif page == "Dead Stock":
             dead_df["ROOT_CAUSE"] = dead_df["_override_cause"].combine_first(dead_df["ROOT_CAUSE"])
             dead_df = dead_df.drop(columns=["_override_cause"])
         dead_df["ROOT_CAUSE"]      = dead_df["ROOT_CAUSE"].fillna("No history")
-        dead_df["MONTHS_TO_CLEAR"] = dead_df["CANONICAL_NAME"].map(_months_clear_map)
+        # Override 1: procurement gap rows whose own DAYS_IDLE >= 90 — the canonical-name
+        # lookup uses min(days_idle) so a high-idle sibling can get a false tag.
+        _pg_mask = (dead_df["ROOT_CAUSE"] == "Procurement gap") & (pd.to_numeric(dead_df["DAYS_IDLE"], errors="coerce") >= 90)
+        dead_df.loc[_pg_mask, "ROOT_CAUSE"] = "Over-ordered"
+
+        # Override 2: procurement gap rows where corrected MTC > 12 months — ITR was measured
+        # over 180 days but current 90-day demand is near-zero, indicating genuine over-stock
+        # rather than a temporary order gap.  (Stress-tested: this catches only true outliers
+        # — RIVAROXABAN 10MG at 107 mo — and creates zero false positives.)
+        _pg_mtc_mask = (
+            (dead_df["ROOT_CAUSE"] == "Procurement gap")
+            & (pd.to_numeric(dead_df["MONTHS_TO_CLEAR"], errors="coerce") > 12)
+        )
+        dead_df.loc[_pg_mtc_mask, "ROOT_CAUSE"] = "Over-ordered"
+
+        if "MONTHS_TO_CLEAR" not in dead_df.columns:
+            dead_df["MONTHS_TO_CLEAR"] = None
 
     # Procurement gap items stay in dead_df and stat strip counts — they are visible to the
     # pharmacist but labelled so they understand these are likely self-resolving.
@@ -1579,7 +1617,7 @@ elif page == "Dead Stock":
             .agg(
                 SKUs=("CANONICAL_NAME", "count"),
                 Value=(_rc_val_col, "sum"),
-                Avg_months_to_clear=("MONTHS_TO_CLEAR", "mean"),
+                Avg_months_to_clear=("MONTHS_TO_CLEAR", "median"),
             )
             .reset_index()
         )
@@ -1609,7 +1647,7 @@ elif page == "Dead Stock":
                   <div style="font-size:10px;font-weight:600;color:#6B7280;text-transform:uppercase;letter-spacing:0.05em;">{_cause}</div>
                   <div style="font-size:26px;font-weight:700;color:{_clr};margin:4px 0 2px;">{_skus}</div>
                   <div style="font-size:11px;color:#374151;">SKUs · {fmt_kes_millions(_val)}</div>
-                  {"<div style='font-size:10px;color:#9CA3AF;margin-top:3px;'>Clears in ~" + str(round(_months, 1)) + " mo</div>" if _show_clear else ""}
+                  {"<div style='font-size:10px;color:#9CA3AF;margin-top:3px;'>Clears in " + (">3yr" if _months > 36 else "~" + str(round(_months, 1)) + " mo") + "</div>" if _show_clear else ""}
                 </div>
                 """,
                 unsafe_allow_html=True,
@@ -1672,6 +1710,11 @@ elif page == "Dead Stock":
         if "CANONICAL_NAME" in _disp_detail.columns:
             _disp_detail["CANONICAL_NAME"] = _disp_detail["CANONICAL_NAME"].map(fmt_drug_name)
 
+        # Cap display at 36 months (>3yr) — underlying value stays intact for sorting/export
+        if "MONTHS_TO_CLEAR" in _disp_detail.columns:
+            _mtc_num = pd.to_numeric(_disp_detail["MONTHS_TO_CLEAR"], errors="coerce")
+            _disp_detail["MONTHS_TO_CLEAR"] = _mtc_num.where(_mtc_num <= 36, other=None)
+
         st.dataframe(
             _disp_detail.rename(columns={
                 "CANONICAL_NAME": "Drug", "DRUG_GROUP": "Group",
@@ -1688,7 +1731,7 @@ elif page == "Dead Stock":
                 "Stock value (KES)": st.column_config.NumberColumn(format="KES %,.0f"),
                 "SOH":               st.column_config.NumberColumn(format="%,.1f"),
                 "Months to clear":   st.column_config.NumberColumn(format="%.1f mo",
-                                        help="At current (recent 90d) demand rate"),
+                                        help="At current 90-day demand rate · blank = >3yr or no recent demand"),
                 "Recent ITR (6mo)":  st.column_config.NumberColumn(format="%.1f×",
                                         help="Inventory turns in last 6 months — 0 = no recent dispensing"),
                 "Hist. ITR (2yr)":   st.column_config.NumberColumn(format="%.1f×",

--- a/analytics_app/dashboards/ksh/ksh_inventory_intelligence.py
+++ b/analytics_app/dashboards/ksh/ksh_inventory_intelligence.py
@@ -217,12 +217,20 @@ def _load_climate(lat: float, lon: float, ref_date_str: str):
     _rd = parse_ref_date(ref_date_str)
     return get_climate_signal(_rd)
 
-import datetime as _dt
 _ref_date_parsed = parse_ref_date(_ref_date)
 
-# Seasonal engine is only meaningful for live facilities. Historical schemas
-# (ref_date > 90 days in the past) would surface peaks from years ago.
-_is_live_schema = _ref_date_parsed >= (_dt.date.today() - _dt.timedelta(days=90))
+# Date the whole dashboard is anchored to — the most recent day of data, not the
+# wall-clock date. Shown to users so figures read "as of last data" and aren't
+# mistaken for real-time. Falls back to today when ref_date is CURRENT_DATE.
+_as_of_date = _ref_date_parsed
+_as_of_label = _as_of_date.strftime("%A, %d %b %Y")
+
+# Seasonal engine is only meaningful for active facilities. Use the registry
+# flag, not ref-date recency: KSH is live but its data can lag the calendar by
+# months, so the ref_date (now anchored to MAX(dispensed_at)) may sit >90 days
+# in the past while the facility is still active. Historical schemas (is_live
+# False) stay gated off so they don't surface peaks from years ago.
+_is_live_schema = fac.is_live
 
 if _is_live_schema:
     _climate_signal    = _load_climate(KISUMU_LAT, KISUMU_LON, _ref_date)
@@ -261,7 +269,7 @@ if page == "Today's Briefing":
 
     page_header(
         title="Today's Briefing",
-        subtitle=f"Operational summary · {pd.Timestamp.now().strftime('%A, %d %b %Y')}",
+        subtitle=f"Operational summary · as of {_as_of_label} (latest data)",
         facility_label=fac.label,
         is_live=fac.is_live,
     )


### PR DESCRIPTION
Two related pieces of KSH inventory work.

1. Digest (commit abcf704)
   - Migrate daily digest from raw smtplib to Django EmailMultiAlternatives
   - Feed engine-derived KPI counts (not raw SQL kpi) into the digest
   - Add a Seasonal Demand Signals section (HTML + plaintext)
  
2. Dashboard fixes (commit 9626097)
   - Anchor ref_date to MAX(dispensed_at) so lookback windows find data
     (fixes blank Patient Risk / Stockout Watch / briefing patient monitor)
   - Show "as of <date>" in briefing; keep seasonal engine on for live-but-lagging data
   - Guard NaN therapeutic_class/subclass (fixes 'float has no attribute strip' crash)
   - CSS: widen container + clear fixed header (title was hidden), wrap KPI labels, bump fonts
